### PR TITLE
Added i18n for 'No events' message.

### DIFF
--- a/the-events-calendar-shortcode.php
+++ b/the-events-calendar-shortcode.php
@@ -74,7 +74,9 @@ class Events_Calendar_Shortcode
 			'past' => null,
 			'venue' => 'false',
 			'author' => null,
-			'message' => 'There are no upcoming events at this time.',
+			'message' => sprintf(
+				__( 'There are no upcoming %s at this time.', 'tribe-events-calendar' ),
+				tribe_get_event_label_plural() ),
 			'key' => 'End Date',
 			'order' => 'ASC',
 			'viewall' => 'false',


### PR DESCRIPTION
For non-English web sites, it makes sense to  localize the "No upcoming events" message. The translations are contained in the "The Events Calenar" plugin.
