### PR TITLE
ecs_event_list_viewall_text and get_excerpt improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,101 @@ The shortcode displays lists of your events. You can control the event display w
   [ecs-list-events cat='festival' key='start date']
   ```
 
+## Shortcode Filters With Examples
+
+**ecs_event_list_title**
+
+    add_filter( 'ecs_event_list_title', 'filter_category_name_from_title', 10, 2 );
+    function filter_category_name_from_title( $title, $atts ) {
+
+	    if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
+
+		    $atts['cat'] = trim( $atts['cat'] );
+
+		    $term = get_term_by( 'name', $atts['cat'], 'tribe_events_cat', 'OBJECT' );
+
+		    ( $term === false ? $term = get_term_by( 'slug', $atts['cat'], 'tribe_events_cat', 'OBJECT' ) : '' ); // If the slug was strangely provided
+
+		    $title = str_replace( $term->name . ' &#8211; ', '', $title ); // Filter "<CATEGORY NAME> - " from title. Must be HTML Entity in the str_replace().
+
+		    $title = trim( $title );
+
+	    }
+
+	    return $title;
+
+    }
+
+**ecs_event_list_details**
+
+    add_filter( 'ecs_event_list_details', 'change_events_time_to_link', 10, 2 );
+    function change_events_time_to_link( $text, $atts ) {
+
+	    if ( strpos( $atts['contentorder'], 'title' ) !== false ) {
+
+            // If we are not showing the Title, then wrap the Date/Time in a Link to the Event
+		    $text = '<a href = "' . tribe_get_event_link() . '" rel = "bookmark">' . $text . '</a>';
+
+	    }
+
+	    return $text;
+
+    }
+
+**ecs_event_list_venue**
+
+    add_filter( 'ecs_event_list_venue', 'change_events_venue_prefix', 10, 2 );
+    function change_events_venue_prefix( $text, $atts ) {
+
+        // Replace <em>at</em> with whatever you would like via str_replace()
+	    $text = str_replace( '<em>at</em>', 'Location:', $text );
+
+	    return $text;
+
+    }
+
+**ecs_event_list_viewall_link**
+
+    add_filter( 'ecs_event_list_viewall_link', 'change_events_links_to_category', 10, 2 );
+    function change_events_links_to_category( $link, $atts ) {
+
+	    if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
+
+		    $atts['cat'] = trim( $atts['cat'] );
+
+		    $term = get_term_by( 'name', $atts['cat'], 'tribe_events_cat', 'OBJECT' );
+
+		    ( $term === false ? $term = get_term_by( 'slug', $atts['cat'], 'tribe_events_cat', 'OBJECT' ) : '' ); // If the slug was strangely provided
+
+		    $link = get_term_link( $term->term_id, 'tribe_events_cat' );
+
+	    }
+
+	    return $link;
+
+    }
+
+**ecs_event_list_viewall_text**
+
+    add_filter( 'ecs_event_list_viewall_text', 'change_events_viewall_text_to_category', 10, 2 );
+    function change_events_viewall_text_to_category( $text, $atts ) {
+
+	    if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
+
+		    $atts['cat'] = trim( $atts['cat'] );
+
+		    $term = get_term_by( 'name', $atts['cat'], 'tribe_events_cat', 'OBJECT' );
+
+		    ( $term === false ? $term = get_term_by( 'slug', $atts['cat'], 'tribe_events_cat', 'OBJECT' ) : '' ); // If the slug was strangely provided
+
+            $text = 'View All ' . $term->name . ' Events';
+
+	    }
+
+	    return $text;
+
+    }
+
 ## Questions about this project?
 
 Please feel free to report any bug found. Pull requests, issues, and plugin recommendations are more than welcome!

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The shortcode displays lists of your events. You can control the event display w
     add_filter( 'ecs_event_list_details', 'change_events_time_to_link', 10, 2 );
     function change_events_time_to_link( $text, $atts ) {
 
-	    if ( strpos( $atts['contentorder'], 'title' ) !== false ) {
+	    if ( ( isset( $atts['contentorder'] ) ) && ( ! in_array( 'title', $atts['contentorder'] ) ) ) {
 
             // If we are not showing the Title, then wrap the Date/Time in a Link to the Event
 		    $text = '<a href = "' . tribe_get_event_link() . '" rel = "bookmark">' . $text . '</a>';

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === The Events Calendar Shortcode ===
-Contributors:  dandelionweb, ankitpokhrel,sujin2f
+Contributors:  dandelionweb, ankitpokhrel, sujin2f, d4mation
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=JEMTB4U8SYFL6
 Tags: event, events, calendar, shortcode, modern tribe
 Requires at least: 3.0
@@ -88,6 +88,101 @@ The plugin does not include styling. Events are listed in ul li tags with approp
 
 = How do I include a list of events in a page template? =
 include echo do_shortcode("[ecs-list-events]"); in the template where you want the events list to display.
+
+= What Filters are Available? Can I Have Some Examples? =
+
+**ecs_event_list_title**
+
+`add_filter( 'ecs_event_list_title', 'filter_category_name_from_title', 10, 2 );
+function filter_category_name_from_title( $title, $atts ) {
+
+	if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
+
+		$atts['cat'] = trim( $atts['cat'] );
+
+		$term = get_term_by( 'name', $atts['cat'], 'tribe_events_cat', 'OBJECT' );
+
+		( $term === false ? $term = get_term_by( 'slug', $atts['cat'], 'tribe_events_cat', 'OBJECT' ) : '' ); // If the slug was strangely provided
+
+		$title = str_replace( $term->name . ' &#8211; ', '', $title ); // Filter "<CATEGORY NAME> - " from title. Must be HTML Entity in the str_replace().
+
+		$title = trim( $title );
+
+	}
+
+	return $title;
+
+}`
+
+**ecs_event_list_details**
+
+`add_filter( 'ecs_event_list_details', 'change_events_time_to_link', 10, 2 );
+function change_events_time_to_link( $text, $atts ) {
+
+	if ( strpos( $atts['contentorder'], 'title' ) !== false ) {
+
+        // If we are not showing the Title, then wrap the Date/Time in a Link to the Event
+		$text = '<a href = "' . tribe_get_event_link() . '" rel = "bookmark">' . $text . '</a>';
+
+	}
+
+	return $text;
+
+}`
+
+**ecs_event_list_venue**
+
+`add_filter( 'ecs_event_list_venue', 'change_events_venue_prefix', 10, 2 );
+function change_events_venue_prefix( $text, $atts ) {
+
+    // Replace <em>at</em> with whatever you would like via str_replace()
+	$text = str_replace( '<em>at</em>', 'Location:', $text );
+
+	return $text;
+
+}`
+
+**ecs_event_list_viewall_link**
+
+`add_filter( 'ecs_event_list_viewall_link', 'change_events_links_to_category', 10, 2 );
+function change_events_links_to_category( $link, $atts ) {
+
+	if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
+
+		$atts['cat'] = trim( $atts['cat'] );
+
+		$term = get_term_by( 'name', $atts['cat'], 'tribe_events_cat', 'OBJECT' );
+
+		( $term === false ? $term = get_term_by( 'slug', $atts['cat'], 'tribe_events_cat', 'OBJECT' ) : '' ); // If the slug was strangely provided
+
+		$link = get_term_link( $term->term_id, 'tribe_events_cat' );
+
+	}
+
+	return $link;
+
+}`
+
+**ecs_event_list_viewall_text**
+
+`add_filter( 'ecs_event_list_viewall_text', 'change_events_viewall_text_to_category', 10, 2 );
+function change_events_viewall_text_to_category( $text, $atts ) {
+
+	if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
+
+		$atts['cat'] = trim( $atts['cat'] );
+
+		$term = get_term_by( 'name', $atts['cat'], 'tribe_events_cat', 'OBJECT' );
+
+		( $term === false ? $term = get_term_by( 'slug', $atts['cat'], 'tribe_events_cat', 'OBJECT' ) : '' ); // If the slug was strangely provided
+
+        $text = 'View All ' . $term->name . ' Events';
+
+	}
+
+	return $text;
+
+}`
 
 == Upgrade Notice ==
 = 1.0.11 =

--- a/readme.txt
+++ b/readme.txt
@@ -93,7 +93,8 @@ include echo do_shortcode("[ecs-list-events]"); in the template where you want t
 
 **ecs_event_list_title**
 
-`add_filter( 'ecs_event_list_title', 'filter_category_name_from_title', 10, 2 );
+`
+add_filter( 'ecs_event_list_title', 'filter_category_name_from_title', 10, 2 );
 function filter_category_name_from_title( $title, $atts ) {
 
 	if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
@@ -112,14 +113,16 @@ function filter_category_name_from_title( $title, $atts ) {
 
 	return $title;
 
-}`
+}
+`
 
 **ecs_event_list_details**
 
-`add_filter( 'ecs_event_list_details', 'change_events_time_to_link', 10, 2 );
+`
+add_filter( 'ecs_event_list_details', 'change_events_time_to_link', 10, 2 );
 function change_events_time_to_link( $text, $atts ) {
 
-	if ( strpos( $atts['contentorder'], 'title' ) !== false ) {
+	if ( ( isset( $atts['contentorder'] ) ) && ( ! in_array( 'title', $atts['contentorder'] ) ) ) {
 
         // If we are not showing the Title, then wrap the Date/Time in a Link to the Event
 		$text = '<a href = "' . tribe_get_event_link() . '" rel = "bookmark">' . $text . '</a>';
@@ -128,11 +131,13 @@ function change_events_time_to_link( $text, $atts ) {
 
 	return $text;
 
-}`
+}
+`
 
 **ecs_event_list_venue**
 
-`add_filter( 'ecs_event_list_venue', 'change_events_venue_prefix', 10, 2 );
+`
+add_filter( 'ecs_event_list_venue', 'change_events_venue_prefix', 10, 2 );
 function change_events_venue_prefix( $text, $atts ) {
 
     // Replace <em>at</em> with whatever you would like via str_replace()
@@ -140,7 +145,8 @@ function change_events_venue_prefix( $text, $atts ) {
 
 	return $text;
 
-}`
+}
+`
 
 **ecs_event_list_viewall_link**
 
@@ -165,7 +171,8 @@ function change_events_links_to_category( $link, $atts ) {
 
 **ecs_event_list_viewall_text**
 
-`add_filter( 'ecs_event_list_viewall_text', 'change_events_viewall_text_to_category', 10, 2 );
+`
+add_filter( 'ecs_event_list_viewall_text', 'change_events_viewall_text_to_category', 10, 2 );
 function change_events_viewall_text_to_category( $text, $atts ) {
 
 	if ( ( isset( $atts['cat'] ) ) && ( $atts['cat'] !== '' ) && ( strpos( $atts['cat'], ',' ) === false ) ) { // If multiple Categories specified, bail
@@ -182,7 +189,8 @@ function change_events_viewall_text_to_category( $text, $atts ) {
 
 	return $text;
 
-}`
+}
+`
 
 == Upgrade Notice ==
 = 1.0.11 =

--- a/the-events-calendar-shortcode.php
+++ b/the-events-calendar-shortcode.php
@@ -193,12 +193,12 @@ class Events_Calendar_Shortcode
 								$thumbWidth = is_numeric($atts['thumbwidth']) ? $atts['thumbwidth'] : '';
 								$thumbHeight = is_numeric($atts['thumbheight']) ? $atts['thumbheight'] : '';
 								if( !empty($thumbWidth) && !empty($thumbHeight) ) {
-									$output .= get_the_post_thumbnail(get_the_ID(), array($thumbWidth, $thumbHeight) );
+									$output .= get_the_post_thumbnail($post->ID, array($thumbWidth, $thumbHeight) );
 								} else {
 
 									$size = ( !empty($thumbWidth) && !empty($thumbHeight) ) ? array( $thumbWidth, $thumbHeight ) : 'medium';
 
-									if ( $thumb = get_the_post_thumbnail( get_the_ID(), $size ) ) {
+									if ( $thumb = get_the_post_thumbnail( $post->ID, $size ) ) {
 										$output .= '<a href="' . tribe_get_event_link() . '">';
 										$output .= $thumb;
 										$output .= '</a>';
@@ -234,7 +234,7 @@ class Events_Calendar_Shortcode
 			$output .= '</ul>';
 
 			if( self::isValid($atts['viewall']) ) {
-				$output .= '<span class="ecs-all-events"><a href="' . apply_filters( 'ecs_event_list_viewall_link', tribe_get_events_link(), $atts ) .'" rel="bookmark">' . translate( 'View All Events', 'tribe-events-calendar' ) . '</a></span>';
+				$output .= '<span class="ecs-all-events"><a href="' . apply_filters( 'ecs_event_list_viewall_link', tribe_get_events_link(), $atts ) .'" rel="bookmark">' . translate( apply_filters( 'ecs_event_list_viewall_text', 'View All Events', $atts ), 'tribe-events-calendar' ) . '</a></span>';
 			}
 
 		} else { //No Events were Found
@@ -278,7 +278,9 @@ class Events_Calendar_Shortcode
 		$excerpt = strip_tags( strip_shortcodes($excerpt) );
 		$excerpt = substr($excerpt, 0, $limit);
 		$excerpt = trim(preg_replace( '/\s+/', ' ', $excerpt));
-		$excerpt .= '...';
+        if ( strlen( $excerpt ) > $limit ) {
+		  $excerpt .= '...';
+        }
 
 		return $excerpt;
 	}

--- a/the-events-calendar-shortcode.php
+++ b/the-events-calendar-shortcode.php
@@ -224,7 +224,7 @@ class Events_Calendar_Shortcode
 
 						case 'venue' :
 							if( self::isValid($atts['venue']) ) {
-								$output .= '<span class="duration venue"><em> at </em>' . apply_filters( 'ecs_event_list_venue', tribe_get_venue(), $atts ) . '</span>';
+								$output .= '<span class="duration venue">' . apply_filters( 'ecs_event_list_venue', ' <em>at</em> ' . tribe_get_venue(), $atts ) . '</span>';
 							}
 							break;
 					}
@@ -278,9 +278,9 @@ class Events_Calendar_Shortcode
 		$excerpt = strip_tags( strip_shortcodes($excerpt) );
 		$excerpt = substr($excerpt, 0, $limit);
 		$excerpt = trim(preg_replace( '/\s+/', ' ', $excerpt));
-        if ( strlen( $excerpt ) > $limit ) {
-		  $excerpt .= '...';
-        }
+		if ( strlen( $excerpt ) > $limit ) {
+			$excerpt .= '...';
+		}
 
 		return $excerpt;
 	}


### PR DESCRIPTION
Added ecs_event_list_viewall_text filter and made the private function get_excerpt not add ellipses unless it actually exceeds the character limit.

get_the_ID() was also changed to $post->ID to avoid extra, unnecessary, function calls.
